### PR TITLE
some sample cucumber tests

### DIFF
--- a/test/gerkin/tests/features/data_create.feature
+++ b/test/gerkin/tests/features/data_create.feature
@@ -1,0 +1,28 @@
+@data
+Feature: Create new record in registry
+  Request endpoint: POST /data/{code}/{version}/create
+  see https://govstack.gitbook.io/specification/v/version-0.9.0/building-blocks/digital-registries/8-service-apis#docs-internal-guid-f400fe68-7fff-bffb-3d00-0b067c81eb40
+
+  A Registration BB application makes a request to the Digital Registries BB API to create a new record
+  # TODO: merge create_mcts_record.feature into this feature and remove one file
+
+  Background:
+    Given database with the valid schema has been set up
+
+  Scenario: Successfully create new record
+    Send form data to Registration CREATE API of MCTS DB.
+    Given "Sona" has entered all required data in the Registration e-service registration form
+    When "Sona" pushes a button "Send application"
+    Then the MCC system makes a request to Registration BB MCTS DB CREATE API
+    And fills the form data field with response information <MCTS ID>
+
+  Scenario: Trying to create record that already exists
+    TODO: do we verify some kind of "duplicate" definition? (e.g. a citizen ID that should be unique across records)
+    Given I have made a successful CREATE request for a new record with <unique-record-id> before
+    When I make a CREATE request identical to the earlier one, with the same <unique-record-id>
+    Then ???
+
+  Scenario: Trying to create new record in non-existing database
+    Given database <id> does not exist
+    When I make a CREATE request to /data/<id>/3.0/create
+    Then I receive a HTTP 400 response (TODO: what is the exact response here? seems missing from the OpenAPI spec so far)

--- a/test/gerkin/tests/features/schema_read.feature
+++ b/test/gerkin/tests/features/schema_read.feature
@@ -1,0 +1,17 @@
+@admin
+Feature: API reads existing registry database schema
+  Request endpoint: GET /api/V1/database/{id}
+  see https://govstack.gitbook.io/specification/v/version-0.9.0/building-blocks/digital-registries/8-service-apis#8.11-database-schema-read
+
+  Scenario: Successfully read schema
+    Given Database <id> exists in registry
+    When I send a request to read schema of <id>
+    Then I receive a response HTTP 200 with the database info according to https://github.com/GovStackWorkingGroup/BuildingBlockAPI/blob/4ed5a083b6fcc84b2394d9c71b7ecc2126082c8f/DigitalRegistriesBB/GovStack_Digital_registries_BB_Database_API_template-1.1.0.json#L227
+
+  Scenario: Fail to read schema of database that does not exist
+    Given Database <id> does not exist in registry
+    When I send a request to read schema of <id>
+    Then I receive a HTTP 404 error response
+
+  Scenario: Failed to read schema because access denied for this request
+    TODO: is this a specific scenario here or is auth handled generically at a higher level?


### PR DESCRIPTION
Draft of some sample cucumber test cases, so that we can settle on exact structure and objectives.

Remarks:
- These are not final definitions yet but should rather serve as a basis to discuss and get feedback on the overall approach.
- I tried to keep the cases abstract - away from the concrete use case example - as suggested. Cucumber documentation does in some places recommend using real-life examples however. This is a possible discussion point still.
- As the registries BB is a very generic API only, my tests are mostly replication what is defined in the OpenAPI spec already (i.e. what requests and different responses are possible). Some responses of the "non-happy paths" are still missing in the OpenAPI specs however.