### PR TITLE
TECH-813: Added workflow for triggering CircleCI on merge

### DIFF
--- a/.github/workflows/trigger-circleci.yaml
+++ b/.github/workflows/trigger-circleci.yaml
@@ -1,0 +1,25 @@
+name: Trigger CircleCI on PR merge
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  trigger-circleci:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+    - name: Trigger CircleCI Workflow
+      run: |
+        curl -u ${CIRCLECI_API_TOKEN}: -X POST \
+        --header "Content-Type: application/json" \
+        -d '{
+          "branch": "${{ github.head_ref }}",
+          "parameters": {
+            "run_workflow": true
+          }
+        }' \
+        https://circleci.com/api/v2/project/gh/${{ github.repository }}/pipeline
+      env:
+        CIRCLECI_API_TOKEN: ${{ secrets.CIRCLECI_API_TOKEN }}


### PR DESCRIPTION
Part of [TECH-813](https://govstack-global.atlassian.net/browse/TECH-813). CircleCI executions are done only on code push. When merge is done then workflow is not triggered on new branch because it's treated as already tested. 
We need to have additional trigger that would call the job on merge event. 

[TECH-813]: https://govstack-global.atlassian.net/browse/TECH-813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ