### PR TITLE
TECH-926: deleted return statement from scenarios

### DIFF
--- a/test/openAPI/features/support/data_create.js
+++ b/test/openAPI/features/support/data_create.js
@@ -43,7 +43,7 @@ When(
 When(
   'User provides body with parameters: {string} as ID, {string} as FirstName, {string} as LastName, {string} as BirthCertificateID',
   function (ID, FirstName, LastName, BirthCertificateID) {
-    return specDataCreate.withBody({
+    specDataCreate.withBody({
       write: {
         content: {
           ID: replaceKeyWithValueFromJson(ID),
@@ -59,7 +59,7 @@ When(
 When(
   'User provides parameters: {string} as ID, {string} as FirstName, {string} as LastName, {string} as BirthCertificateID',
   function (ID, FirstName, LastName, BirthCertificateID) {
-    return specDataCreate.withBody({
+    specDataCreate.withBody({
       write: {
         content: {
           ID: replaceKeyWithValueFromJson(ID),


### PR DESCRIPTION
Ticket:
https://govstack-global.atlassian.net/browse/TECH-926

## Description
It appears that returning promises caused them to resolve, which in turn triggered a request when setting body parameters.

Changes:
- Removed the "return" statement from two steps.

## How Has This Been Tested?
1. The openIMIS example app passed all 5 tests for "create registry."
2. Wireshark confirmed that request packages are not sent twice per scenario.
